### PR TITLE
More tests and bug corrections

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,25 +4,31 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaVersion: 2018,
-    sourceType: "module"
+    sourceType: "module",
   },
   settings: {
     "import/parsers": {
-      "@typescript-eslint/parser": [".ts", ".tsx"]
+      "@typescript-eslint/parser": [".ts", ".tsx"],
     },
     "import/resolver": {
       typescript: {
-        alwaysTryTypes: true
-      }
-    }
+        alwaysTryTypes: true,
+      },
+    },
   },
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:@repo-tooling/dprint/recommended"
+    "plugin:@repo-tooling/dprint/recommended",
   ],
-  plugins: ["deprecation", "import", "sort-destructure-keys", "simple-import-sort", "codegen"],
+  plugins: [
+    "deprecation",
+    "import",
+    "sort-destructure-keys",
+    "simple-import-sort",
+    "codegen",
+  ],
   rules: {
     "codegen/codegen": "error",
     "no-fallthrough": "off",
@@ -39,20 +45,27 @@ module.exports = {
     "import/no-duplicates": "error",
     "import/no-unresolved": "off",
     "import/order": "off",
+    "linebreak-style": ["error", "unix"],
     "simple-import-sort/imports": "off",
     "sort-destructure-keys/sort-destructure-keys": "error",
     "deprecation/deprecation": "off",
-    "@typescript-eslint/array-type": ["warn", { "default": "generic", "readonly": "generic" }],
+    "@typescript-eslint/array-type": [
+      "warn",
+      { default: "generic", readonly: "generic" },
+    ],
     "@typescript-eslint/member-delimiter-style": 0,
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/consistent-type-imports": "warn",
-    "@typescript-eslint/no-unused-vars": ["error", {
-      "argsIgnorePattern": "^_",
-      "varsIgnorePattern": "^_"
-    }],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+      },
+    ],
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
@@ -65,15 +78,15 @@ module.exports = {
       "error",
       {
         config: {
-          "indentWidth": 2,
-          "lineWidth": 120,
-          "semiColons": "asi",
-          "quoteStyle": "alwaysDouble",
-          "trailingCommas": "never",
-          "operatorPosition": "maintain",
-          "arrowFunction.useParentheses": "force"
-        }
-      }
-    ]
-  }
-}
+          indentWidth: 2,
+          lineWidth: 120,
+          semiColons: "asi",
+          quoteStyle: "alwaysDouble",
+          trailingCommas: "never",
+          operatorPosition: "maintain",
+          "arrowFunction.useParentheses": "force",
+        },
+      },
+    ],
+  },
+};

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1,4 +1,3 @@
-import { pipe } from "@effect/data/Function"
 import * as Syntax from "@effect/parser/Syntax"
 
 // const hello = Syntax.string("hello", "h")
@@ -6,12 +5,9 @@ import * as Syntax from "@effect/parser/Syntax"
 // const world = Syntax.string("world", "w")
 
 // const all = Syntax.string("all", "a")
+const charA = Syntax.as(Syntax.char("a"), "a")
+const grammar = Syntax.atLeast(charA, 1)
 
-const grammar = pipe(
-  Syntax.anyChar,
-  Syntax.repeatWithSeparator1(Syntax.char("-"))
-)
-
-const result = Syntax.printString(grammar, ["a", "b", "c"])
+const result = Syntax.parseStringWith(grammar, "bc", "stack-safe")
 
 console.log(result)

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1,11 +1,17 @@
 import { pipe } from "@effect/data/Function"
 import * as Syntax from "@effect/parser/Syntax"
 
-pipe(
-  Syntax.char("a"),
-  Syntax.orElse(() => Syntax.char("b")),
-  Syntax.repeatWithSeparator1(Syntax.char(",")),
-  Syntax.captureString,
-  Syntax.zipLeft(Syntax.char("!")),
-  Syntax.parseStringWith("a,a,b,a,b,b!", "stack-safe")
+// const hello = Syntax.string("hello", "h")
+
+// const world = Syntax.string("world", "w")
+
+// const all = Syntax.string("all", "a")
+
+const grammar = pipe(
+  Syntax.anyChar,
+  Syntax.repeatWithSeparator1(Syntax.char("-"))
 )
+
+const result = Syntax.printString(grammar, ["a", "b", "c"])
+
+console.log(result)

--- a/package.json
+++ b/package.json
@@ -52,10 +52,12 @@
       "require": "./build/cjs/index.js"
     },
     "./*": {
-      "require": "./build/cjs/*.js"
+      "require": "./build/cjs/*.js",
+      "import": "./src/*.ts"
     }
   },
   "dependencies": {
+    "-": "^0.0.1",
     "@effect/data": "~0.12.9",
     "@effect/io": "~0.26.1"
   },
@@ -71,14 +73,15 @@
     "@effect/docgen": "^0.1.1",
     "@effect/language-service": "^0.0.19",
     "@repo-tooling/eslint-plugin-dprint": "^0.0.4",
-    "@types/node": "^20.3.0",
-    "@typescript-eslint/eslint-plugin": "^5.59.9",
-    "@typescript-eslint/parser": "^5.59.9",
-    "@vitejs/plugin-react": "^4.0.0",
-    "@vitest/coverage-v8": "^0.32.0",
+    "@types/node": "^20.3.1",
+    "@typescript-eslint/eslint-plugin": "^5.60.0",
+    "@typescript-eslint/parser": "^5.60.0",
+    "@vitejs/plugin-react": "^4.0.1",
+    "@vitest/coverage-v8": "^0.32.2",
+    "@vitest/ui": "^0.32.2",
     "babel-plugin-annotate-pure-calls": "^0.4.0",
     "concurrently": "^8.2.0",
-    "eslint": "^8.42.0",
+    "eslint": "^8.43.0",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-codegen": "0.17.0",
     "eslint-plugin-deprecation": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "test": "vitest",
     "coverage": "vitest run --coverage"
   },
-  "type": "module",
   "exports": {
     ".": {
       "require": "./build/cjs/index.js"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test": "vitest",
     "coverage": "vitest run --coverage"
   },
+  "type": "module",
   "exports": {
     ".": {
       "require": "./build/cjs/index.js"

--- a/package.json
+++ b/package.json
@@ -58,24 +58,24 @@
   },
   "dependencies": {
     "-": "^0.0.1",
-    "@effect/data": "~0.12.9",
-    "@effect/io": "~0.26.1"
+    "@effect/data": "~0.12.10",
+    "@effect/io": "~0.28.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.5",
     "@babel/core": "^7.22.5",
     "@babel/plugin-transform-modules-commonjs": "^7.22.5",
     "@changesets/changelog-github": "^0.4.8",
-    "@changesets/cli": "^2.26.1",
+    "@changesets/cli": "^2.26.2",
     "@effect-ts/build-utils": "0.40.7",
     "@effect-ts/core": "^0.60.5",
     "@effect/babel-plugin": "^0.2.0",
     "@effect/docgen": "^0.1.1",
     "@effect/language-service": "^0.0.19",
     "@repo-tooling/eslint-plugin-dprint": "^0.0.4",
-    "@types/node": "^20.3.1",
-    "@typescript-eslint/eslint-plugin": "^5.60.0",
-    "@typescript-eslint/parser": "^5.60.0",
+    "@types/node": "^20.3.2",
+    "@typescript-eslint/eslint-plugin": "^5.60.1",
+    "@typescript-eslint/parser": "^5.60.1",
     "@vitejs/plugin-react": "^4.0.1",
     "@vitest/coverage-v8": "^0.32.2",
     "@vitest/ui": "^0.32.2",
@@ -92,9 +92,9 @@
     "madge": "^6.1.0",
     "rimraf": "^5.0.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.3",
+    "typescript": "^5.1.6",
     "vite": "^4.3.9",
-    "vitest": "0.32.0"
+    "vitest": "0.32.2"
   },
   "config": {
     "side": [],

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -313,16 +313,6 @@ export const flattenNonEmpty: <Input, Error>(
 ) => Parser<Input, Error, string> = internal.flattenNonEmpty
 
 /**
- * Flattens a result of zipped strings to a single string.
- *
- * @since 1.0.0
- * @category combinators
- */
-export const flattenZippedStrings: <Input, Error>(
-  self: Parser<Input, Error, readonly [string, string]>
-) => Parser<Input, Error, string> = internal.flattenZippedStrings
-
-/**
  * Constructs `Parser` that results in the current input stream position.
  *
  * @since 1.0.0

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -767,11 +767,11 @@ export const zip: {
     that: Parser<Input2, Error2, Result2>
   ): <Input, Error, Result>(
     self: Parser<Input, Error, Result>
-  ) => Parser<Input & Input2, Error2 | Error, readonly [Result, Result2]>
+  ) => Parser<Input & Input2, Error2 | Error, [Result, Result2]>
   <Input, Error, Result, Input2, Error2, Result2>(
     self: Parser<Input, Error, Result>,
     that: Parser<Input2, Error2, Result2>
-  ): Parser<Input & Input2, Error | Error2, readonly [Result, Result2]>
+  ): Parser<Input & Input2, Error | Error2, [Result, Result2]>
 } = internal.zip
 
 /**

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -642,6 +642,16 @@ export const string: <Result>(str: string, result: Result) => Parser<string, str
 export const succeed: <Result>(result: Result) => Parser<unknown, never, Result> = internal.succeed
 
 /**
+ * Lazily constructs a `Parser`.
+ *
+ * @since 1.0.0
+ * @category constructors
+ */
+export const suspend: <Input, Error, Result>(
+  parser: LazyArg<Parser<Input, Error, Result>>
+) => Parser<Input, Error, Result> = internal.suspend
+
+/**
  * Surrounds this parser with the `other` parser. The result is this parser's
  * result.
  *

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -103,7 +103,7 @@ export const anyChar: Parser<string, never, string> = internal.anyChar
 export const anyString: Parser<string, never, string> = internal.anyString
 
 /**
- * Ignores the parser's successful result and result in 'result' instead
+ * Transforms a `Syntax` that results in `void` in a `Syntax` that results in `value`
  *
  * @since 1.0.0
  * @category combinators
@@ -121,7 +121,7 @@ export const as: {
 } = internal.as
 
 /**
- * Maps the result of this parser to the unit value.
+ * Transforms a `Syntax` that results in `from` in a `Syntax` that results in `void`
  *
  * @since 1.0.0
  * @category combinators
@@ -767,11 +767,11 @@ export const zip: {
     that: Parser<Input2, Error2, Result2>
   ): <Input, Error, Result>(
     self: Parser<Input, Error, Result>
-  ) => Parser<Input & Input2, Error2 | Error, [Result, Result2]>
+  ) => Parser<Input & Input2, Error2 | Error, readonly [Result, Result2]>
   <Input, Error, Result, Input2, Error2, Result2>(
     self: Parser<Input, Error, Result>,
     that: Parser<Input2, Error2, Result2>
-  ): Parser<Input & Input2, Error | Error2, [Result, Result2]>
+  ): Parser<Input & Input2, Error | Error2, readonly [Result, Result2]>
 } = internal.zip
 
 /**

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -303,6 +303,26 @@ export const flatten: <Input, Error>(self: Parser<Input, Error, Chunk<string>>) 
   internal.flatten
 
 /**
+ * Flattens a result of parsed strings to a single string.
+ *
+ * @since 1.0.0
+ * @category combinators
+ */
+export const flattenNonEmpty: <Input, Error>(
+  self: Parser<Input, Error, NonEmptyChunk<string>>
+) => Parser<Input, Error, string> = internal.flattenNonEmpty
+
+/**
+ * Flattens a result of zipped strings to a single string.
+ *
+ * @since 1.0.0
+ * @category combinators
+ */
+export const flattenZippedStrings: <Input, Error>(
+  self: Parser<Input, Error, readonly [string, string]>
+) => Parser<Input, Error, string> = internal.flattenZippedStrings
+
+/**
  * Constructs `Parser` that results in the current input stream position.
  *
  * @since 1.0.0

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -297,6 +297,16 @@ export const flattenNonEmpty: <Error, Output>(
 ) => Printer<string, Error, Output> = internal.flattenNonEmpty
 
 /**
+ * Flattens a result of zipped strings to a single string.
+ *
+ * @since 1.0.0
+ * @category combinators
+ */
+export const flattenZippedStrings: <Error, Output>(
+  self: Printer<readonly [string, string], Error, Output>
+) => Printer<string, Error, Output> = internal.flattenZippedStrings
+
+/**
  * A `Printer` computed using a function on the input value.
  *
  * @since 1.0.0

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -84,7 +84,7 @@ export const anyChar: Printer<string, never, string> = internal.anyChar
 export const anyString: Printer<string, never, string> = internal.anyString
 
 /**
- * Ignores the printer's result and input and use `matches` and `from` instead.
+ * Transforms a `Syntax` that results in `from` in a `Syntax` that results in `value`
  *
  * @since 1.0.0
  * @category combinators

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -297,16 +297,6 @@ export const flattenNonEmpty: <Error, Output>(
 ) => Printer<string, Error, Output> = internal.flattenNonEmpty
 
 /**
- * Flattens a result of zipped strings to a single string.
- *
- * @since 1.0.0
- * @category combinators
- */
-export const flattenZippedStrings: <Error, Output>(
-  self: Printer<readonly [string, string], Error, Output>
-) => Printer<string, Error, Output> = internal.flattenZippedStrings
-
-/**
  * A `Printer` computed using a function on the input value.
  *
  * @since 1.0.0

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -287,6 +287,16 @@ export const flatten: <Error, Output>(
 ) => Printer<string, Error, Output> = internal.flatten
 
 /**
+ * Concatenates an input `Chunk<string>` to a `string` to be printed.
+ *
+ * @since 1.0.0
+ * @category combinators
+ */
+export const flattenNonEmpty: <Error, Output>(
+  self: Printer<NonEmptyChunk<string>, Error, Output>
+) => Printer<string, Error, Output> = internal.flattenNonEmpty
+
+/**
  * A `Printer` computed using a function on the input value.
  *
  * @since 1.0.0

--- a/src/Syntax.ts
+++ b/src/Syntax.ts
@@ -335,16 +335,6 @@ export const flattenNonEmpty: <Input, Error, Output>(
 ) => Syntax<Input, Error, Output, string> = internal.flattenNonEmpty
 
 /**
- * Flattens a result of zipped strings to a single string.
- *
- * @since 1.0.0
- * @category combinators
- */
-export const flattenZippedStrings: <Input, Error, Output>(
-  self: Syntax<Input, Error, Output, readonly [string, string]>
-) => Syntax<Input, Error, Output, string> = internal.flattenZippedStrings
-
-/**
  * Constructs a `Syntax` that in parser mode results in the current input
  * stream position.
  *

--- a/src/Syntax.ts
+++ b/src/Syntax.ts
@@ -335,6 +335,16 @@ export const flattenNonEmpty: <Input, Error, Output>(
 ) => Syntax<Input, Error, Output, string> = internal.flattenNonEmpty
 
 /**
+ * Flattens a result of zipped strings to a single string.
+ *
+ * @since 1.0.0
+ * @category combinators
+ */
+export const flattenZippedStrings: <Input, Error, Output>(
+  self: Syntax<Input, Error, Output, readonly [string, string]>
+) => Syntax<Input, Error, Output, string> = internal.flattenZippedStrings
+
+/**
  * Constructs a `Syntax` that in parser mode results in the current input
  * stream position.
  *
@@ -723,7 +733,19 @@ export const surroundedBy: {
 } = internal.surroundedBy
 
 /**
- * Lazily constructs a `Syntax`.
+ * Lazily constructs a `Syntax`. Can be used to construct a recursive parser
+ *
+ * @example
+ *
+ * import { pipe } from "@effect/data/Function"
+ * import * as Syntax from "@effect/parser/Syntax"
+ *
+ * const recursive: Syntax.Syntax<string, string, string, string> = pipe(
+ *      Syntax.digit,
+ *      Syntax.zipLeft(
+ *        pipe(Syntax.suspend(() => recursive), Syntax.orElse(() => Syntax.letter), Syntax.asUnit("?"))
+ *      )
+ * )
  *
  * @since 1.0.0
  * @category constructors

--- a/src/Syntax.ts
+++ b/src/Syntax.ts
@@ -54,6 +54,10 @@ export declare namespace Syntax {
   }
 }
 
+export type V<S extends { readonly [SyntaxTypeId]: { _Value: (..._: any) => any } }> = Parameters<
+  S[SyntaxTypeId]["_Value"]
+>[0]
+
 /**
  * Constructs a `Syntax` for a single alpha-numeric character.
  *
@@ -87,15 +91,13 @@ export const anyChar: Syntax<string, never, string, string> = internal.anyChar
 export const anyString: Syntax<string, never, string, string> = internal.anyString
 
 /**
- * Ignores the `Syntax`'s successful result and result in `value` instead
+ * Transforms a `Syntax` that results in `void` in a `Syntax` that results in `value`
  *
  * @since 1.0.0
  * @category combinators
  */
 export const as: {
-  <Value2>(
-    value: Value2
-  ): <Input, Error, Output>(
+  <Value2>(value: Value2): <Input, Error, Output>(
     self: Syntax<Input, Error, Output, void>
   ) => Syntax<Input, Error, Output, Value2>
   <Input, Error, Output, Value2>(
@@ -105,42 +107,35 @@ export const as: {
 } = internal.as
 
 /**
- * Sets the value of this `Syntax` to the specified `value` and the value to be
- * printed to `toPrint`.
+ * Transforms a `Syntax` that results in `from` in a `Syntax` that results in `value`
  *
  * @since 1.0.0
  * @category combinators
  */
 export const asPrinted: {
-  <Value, Value2>(
-    value: Value2,
-    toPrint: Value
-  ): <Input, Error, Output>(
+  <Value, Value2>(value: Value2, from: Value): <Input, Error, Output>(
     self: Syntax<Input, Error, Output, Value>
   ) => Syntax<Input, Error, Output, Value2>
   <Input, Error, Output, Value, Value2>(
     self: Syntax<Input, Error, Output, Value>,
     value: Value2,
-    toPrint: Value
+    from: Value
   ): Syntax<Input, Error, Output, Value2>
 } = internal.asPrinted
 
 /**
- * Returns a new `Syntax` from the provided syntax that does not consume any
- * input but prints `printed` and results in `void`.
+ * Transforms a `Syntax` that results in `from` in a `Syntax` that results in `void`
  *
  * @since 1.0.0
  * @category combinators
  */
 export const asUnit: {
-  <Value>(
-    printed: Value
-  ): <Input, Error, Output>(
+  <Value>(from: Value): <Input, Error, Output>(
     self: Syntax<Input, Error, Output, Value>
   ) => Syntax<Input, Error, Output, void>
   <Input, Error, Output, Value>(
     self: Syntax<Input, Error, Output, Value>,
-    printed: Value
+    from: Value
   ): Syntax<Input, Error, Output, void>
 } = internal.asUnit
 
@@ -881,8 +876,8 @@ export const whitespace: Syntax<string, string, string, string> = internal.white
 /**
  * Concatenates this `Syntax` with `that` `Syntax`. If the parser of both
  * syntaxes succeeds, the result is the result of this `Syntax`. Otherwise the
- * `Syntax` fails. The printer passes the value to be printed to this printer,
- * and also executes `that` printer with `void` as the input value.
+ * `Syntax` fails. The printer executes `this` printer with `void` as the input value
+ * and also passes the value to be printed to that printer.
  *
  * Note that the right syntax must have `Value` defined as `void`, because there
  * is no way for the printer to reconstruct an arbitrary input for the right
@@ -892,14 +887,14 @@ export const whitespace: Syntax<string, string, string, string> = internal.white
  * @category combinators
  */
 export const zipLeft: {
-  <Input2, Error2, Output2, Value2>(
-    that: Syntax<Input2, Error2, Output2, Value2>
+  <Input2, Error2, Output2>(
+    that: Syntax<Input2, Error2, Output2, void>
   ): <Input, Error, Output, Value>(
     self: Syntax<Input, Error, Output, Value>
   ) => Syntax<Input & Input2, Error2 | Error, Output2 | Output, Value>
-  <Input, Error, Output, Value, Input2, Error2, Output2, Value2>(
+  <Input, Error, Output, Value, Input2, Error2, Output2>(
     self: Syntax<Input, Error, Output, Value>,
-    that: Syntax<Input2, Error2, Output2, Value2>
+    that: Syntax<Input2, Error2, Output2, void>
   ): Syntax<Input & Input2, Error | Error2, Output | Output2, Value>
 } = internal.zipLeft
 
@@ -943,9 +938,9 @@ export const zip: {
     that: Syntax<Input2, Error2, Output2, Value2>
   ): <Input, Error, Output, Value>(
     self: Syntax<Input, Error, Output, Value>
-  ) => Syntax<Input & Input2, Error2 | Error, Output2 | Output, [Value, Value2]>
+  ) => Syntax<Input & Input2, Error2 | Error, Output2 | Output, readonly [Value, Value2]>
   <Input, Error, Output, Value, Input2, Error2, Output2, Value2>(
     self: Syntax<Input, Error, Output, Value>,
     that: Syntax<Input2, Error2, Output2, Value2>
-  ): Syntax<Input & Input2, Error | Error2, Output | Output2, [Value, Value2]>
+  ): Syntax<Input & Input2, Error | Error2, Output | Output2, readonly [Value, Value2]>
 } = internal.zip

--- a/src/Syntax.ts
+++ b/src/Syntax.ts
@@ -330,6 +330,16 @@ export const flatten: <Input, Error, Output>(
 ) => Syntax<Input, Error, Output, string> = internal.flatten
 
 /**
+ * Flattens a result of parsed strings to a single string.
+ *
+ * @since 1.0.0
+ * @category combinators
+ */
+export const flattenNonEmpty: <Input, Error, Output>(
+  self: Syntax<Input, Error, Output, NonEmptyChunk<string>>
+) => Syntax<Input, Error, Output, string> = internal.flattenNonEmpty
+
+/**
  * Constructs a `Syntax` that in parser mode results in the current input
  * stream position.
  *
@@ -716,6 +726,16 @@ export const surroundedBy: {
     other: Syntax<Input2, Error2, Output2, void>
   ): Syntax<Input & Input2, Error | Error2, Output | Output2, Value>
 } = internal.surroundedBy
+
+/**
+ * Lazily constructs a `Syntax`.
+ *
+ * @since 1.0.0
+ * @category constructors
+ */
+export const suspend: <Input, Error, Output, Value>(
+  self: LazyArg<Syntax<Input, Error, Output, Value>>
+) => Syntax<Input, Error, Output, Value> = internal.suspend
 
 /**
  * Maps the parser's successful result with the given function `to`, and maps

--- a/src/Syntax.ts
+++ b/src/Syntax.ts
@@ -943,9 +943,9 @@ export const zip: {
     that: Syntax<Input2, Error2, Output2, Value2>
   ): <Input, Error, Output, Value>(
     self: Syntax<Input, Error, Output, Value>
-  ) => Syntax<Input & Input2, Error2 | Error, Output2 | Output, readonly [Value, Value2]>
+  ) => Syntax<Input & Input2, Error2 | Error, Output2 | Output, [Value, Value2]>
   <Input, Error, Output, Value, Input2, Error2, Output2, Value2>(
     self: Syntax<Input, Error, Output, Value>,
     that: Syntax<Input2, Error2, Output2, Value2>
-  ): Syntax<Input & Input2, Error | Error2, Output | Output2, readonly [Value, Value2]>
+  ): Syntax<Input & Input2, Error | Error2, Output | Output2, [Value, Value2]>
 } = internal.zip

--- a/src/internal_effect_untraced/parser.ts
+++ b/src/internal_effect_untraced/parser.ts
@@ -783,6 +783,16 @@ export const surroundedBy = dual<
 >(2, (self, other) => zipRight(other, zipLeft(self, other)))
 
 /** @internal */
+export const suspend = <Input, Error, Result>(
+  parser: LazyArg<Parser.Parser<Input, Error, Result>>
+): Parser.Parser<Input, Error, Result> => {
+  const op = Object.create(proto)
+  op._tag = "Suspend"
+  op.parser = parser
+  return op
+}
+
+/** @internal */
 export const transformEither = dual<
   <Result, Error2, Result2>(
     f: (result: Result) => Either.Either<Error2, Result2>

--- a/src/internal_effect_untraced/parser.ts
+++ b/src/internal_effect_untraced/parser.ts
@@ -4,7 +4,6 @@ import type { LazyArg } from "@effect/data/Function"
 import { dual, pipe } from "@effect/data/Function"
 import * as Option from "@effect/data/Option"
 import type { Predicate } from "@effect/data/Predicate"
-import * as ReadonlyArray from "@effect/data/ReadonlyArray"
 import * as recursive from "@effect/parser/internal_effect_untraced/parser/recursive"
 import * as stackSafe from "@effect/parser/internal_effect_untraced/parser/stack-safe"
 import * as parserError from "@effect/parser/internal_effect_untraced/parserError"
@@ -445,11 +444,6 @@ export const flatten = <Input, Error>(
 export const flattenNonEmpty = <Input, Error>(
   self: Parser.Parser<Input, Error, Chunk.NonEmptyChunk<string>>
 ): Parser.Parser<Input, Error, string> => map(self, Chunk.join(""))
-
-/** @internal */
-export const flattenZippedStrings = <Input, Error>(
-  self: Parser.Parser<Input, Error, readonly [string, string]>
-): Parser.Parser<Input, Error, string> => map(self, ReadonlyArray.join(""))
 
 /** @internal */
 export const manualBacktracking = <Input, Error, Result>(

--- a/src/internal_effect_untraced/parser.ts
+++ b/src/internal_effect_untraced/parser.ts
@@ -857,11 +857,11 @@ export const zip = dual<
     that: Parser.Parser<Input2, Error2, Result2>
   ) => <Input, Error, Result>(
     self: Parser.Parser<Input, Error, Result>
-  ) => Parser.Parser<Input & Input2, Error | Error2, [Result, Result2]>,
+  ) => Parser.Parser<Input & Input2, Error | Error2, readonly [Result, Result2]>,
   <Input, Error, Result, Input2, Error2, Result2>(
     self: Parser.Parser<Input, Error, Result>,
     that: Parser.Parser<Input2, Error2, Result2>
-  ) => Parser.Parser<Input & Input2, Error | Error2, [Result, Result2]>
+  ) => Parser.Parser<Input & Input2, Error | Error2, readonly [Result, Result2]>
 >(2, (self, that) => zipWith(self, that, (left, right) => [left, right]))
 
 /** @internal */

--- a/src/internal_effect_untraced/parser.ts
+++ b/src/internal_effect_untraced/parser.ts
@@ -4,6 +4,7 @@ import type { LazyArg } from "@effect/data/Function"
 import { dual, pipe } from "@effect/data/Function"
 import * as Option from "@effect/data/Option"
 import type { Predicate } from "@effect/data/Predicate"
+import * as ReadonlyArray from "@effect/data/ReadonlyArray"
 import * as recursive from "@effect/parser/internal_effect_untraced/parser/recursive"
 import * as stackSafe from "@effect/parser/internal_effect_untraced/parser/stack-safe"
 import * as parserError from "@effect/parser/internal_effect_untraced/parserError"
@@ -439,6 +440,16 @@ export const flatMap = dual<
 export const flatten = <Input, Error>(
   self: Parser.Parser<Input, Error, Chunk.Chunk<string>>
 ): Parser.Parser<Input, Error, string> => map(self, Chunk.join(""))
+
+/** @internal */
+export const flattenNonEmpty = <Input, Error>(
+  self: Parser.Parser<Input, Error, Chunk.NonEmptyChunk<string>>
+): Parser.Parser<Input, Error, string> => map(self, Chunk.join(""))
+
+/** @internal */
+export const flattenZippedStrings = <Input, Error>(
+  self: Parser.Parser<Input, Error, readonly [string, string]>
+): Parser.Parser<Input, Error, string> => map(self, ReadonlyArray.join(""))
 
 /** @internal */
 export const manualBacktracking = <Input, Error, Result>(

--- a/src/internal_effect_untraced/parser.ts
+++ b/src/internal_effect_untraced/parser.ts
@@ -857,11 +857,11 @@ export const zip = dual<
     that: Parser.Parser<Input2, Error2, Result2>
   ) => <Input, Error, Result>(
     self: Parser.Parser<Input, Error, Result>
-  ) => Parser.Parser<Input & Input2, Error | Error2, readonly [Result, Result2]>,
+  ) => Parser.Parser<Input & Input2, Error | Error2, [Result, Result2]>,
   <Input, Error, Result, Input2, Error2, Result2>(
     self: Parser.Parser<Input, Error, Result>,
     that: Parser.Parser<Input2, Error2, Result2>
-  ) => Parser.Parser<Input & Input2, Error | Error2, readonly [Result, Result2]>
+  ) => Parser.Parser<Input & Input2, Error | Error2, [Result, Result2]>
 >(2, (self, that) => zipWith(self, that, (left, right) => [left, right]))
 
 /** @internal */

--- a/src/internal_effect_untraced/printer.ts
+++ b/src/internal_effect_untraced/printer.ts
@@ -367,7 +367,7 @@ export const flattenNonEmpty = <Error, Output>(
 /** @internal */
 export const flattenZippedStrings = <Error, Output>(
   self: Printer.Printer<readonly [string, string], Error, Output>
-): Printer.Printer<string, Error, Output> => contramap(self, (from) => tuple("", from))
+): Printer.Printer<string, Error, Output> => contramap(self, (from) => tuple(from[0], from.slice(1)))
 
 /** @internal */
 export const fromInput = <Input, Error, Output>(

--- a/src/internal_effect_untraced/printer.ts
+++ b/src/internal_effect_untraced/printer.ts
@@ -353,8 +353,14 @@ export const filterInput = dual<
       ? Either.right(value)
       : Either.left(error)))
 
+/** @internal */
 export const flatten = <Error, Output>(
   self: Printer.Printer<Chunk.Chunk<string>, Error, Output>
+): Printer.Printer<string, Error, Output> => contramap(self, Chunk.of)
+
+/** @internal */
+export const flattenNonEmpty = <Error, Output>(
+  self: Printer.Printer<Chunk.NonEmptyChunk<string>, Error, Output>
 ): Printer.Printer<string, Error, Output> => contramap(self, Chunk.of)
 
 /** @internal */

--- a/src/internal_effect_untraced/printer.ts
+++ b/src/internal_effect_untraced/printer.ts
@@ -6,7 +6,6 @@ import { constVoid, dual, pipe } from "@effect/data/Function"
 import * as List from "@effect/data/List"
 import * as Option from "@effect/data/Option"
 import type { Predicate } from "@effect/data/Predicate"
-import { tuple } from "@effect/data/Tuple"
 import * as chunkTarget from "@effect/parser/internal_effect_untraced/chunkTarget"
 import * as parserError from "@effect/parser/internal_effect_untraced/parserError"
 import * as _regex from "@effect/parser/internal_effect_untraced/regex"
@@ -363,11 +362,6 @@ export const flatten = <Error, Output>(
 export const flattenNonEmpty = <Error, Output>(
   self: Printer.Printer<Chunk.NonEmptyChunk<string>, Error, Output>
 ): Printer.Printer<string, Error, Output> => contramap(self, Chunk.of)
-
-/** @internal */
-export const flattenZippedStrings = <Error, Output>(
-  self: Printer.Printer<readonly [string, string], Error, Output>
-): Printer.Printer<string, Error, Output> => contramap(self, (from) => tuple(from[0], from.slice(1)))
 
 /** @internal */
 export const fromInput = <Input, Error, Output>(

--- a/src/internal_effect_untraced/printer.ts
+++ b/src/internal_effect_untraced/printer.ts
@@ -6,6 +6,7 @@ import { constVoid, dual, pipe } from "@effect/data/Function"
 import * as List from "@effect/data/List"
 import * as Option from "@effect/data/Option"
 import type { Predicate } from "@effect/data/Predicate"
+import { tuple } from "@effect/data/Tuple"
 import * as chunkTarget from "@effect/parser/internal_effect_untraced/chunkTarget"
 import * as parserError from "@effect/parser/internal_effect_untraced/parserError"
 import * as _regex from "@effect/parser/internal_effect_untraced/regex"
@@ -362,6 +363,11 @@ export const flatten = <Error, Output>(
 export const flattenNonEmpty = <Error, Output>(
   self: Printer.Printer<Chunk.NonEmptyChunk<string>, Error, Output>
 ): Printer.Printer<string, Error, Output> => contramap(self, Chunk.of)
+
+/** @internal */
+export const flattenZippedStrings = <Error, Output>(
+  self: Printer.Printer<readonly [string, string], Error, Output>
+): Printer.Printer<string, Error, Output> => contramap(self, (from) => tuple("", from))
 
 /** @internal */
 export const fromInput = <Input, Error, Output>(

--- a/src/internal_effect_untraced/regex.ts
+++ b/src/internal_effect_untraced/regex.ts
@@ -121,7 +121,7 @@ const IS_DIGIT_REGEX = /^[0-9]$/
 /** @internal */
 export const anyDigit: Regex.Regex = filter((char) => IS_DIGIT_REGEX.test(char))
 
-const IS_LETTER_REGEX = /^[a-z]$/
+const IS_LETTER_REGEX = /^[a-z]$/i
 
 /** @internal */
 export const anyLetter: Regex.Regex = filter((char) => IS_LETTER_REGEX.test(char))

--- a/src/internal_effect_untraced/syntax.ts
+++ b/src/internal_effect_untraced/syntax.ts
@@ -638,11 +638,11 @@ export const zip = dual<
     that: Syntax.Syntax<Input2, Error2, Output2, Value2>
   ) => <Input, Error, Output, Value>(
     self: Syntax.Syntax<Input, Error, Output, Value>
-  ) => Syntax.Syntax<Input & Input2, Error | Error2, Output | Output2, readonly [Value, Value2]>,
+  ) => Syntax.Syntax<Input & Input2, Error | Error2, Output | Output2, [Value, Value2]>,
   <Input, Error, Output, Value, Input2, Error2, Output2, Value2>(
     self: Syntax.Syntax<Input, Error, Output, Value>,
     that: Syntax.Syntax<Input2, Error2, Output2, Value2>
-  ) => Syntax.Syntax<Input & Input2, Error | Error2, Output | Output2, readonly [Value, Value2]>
+  ) => Syntax.Syntax<Input & Input2, Error | Error2, Output | Output2, [Value, Value2]>
 >(2, (self, that) =>
   make(
     _parser.zip(self.parser, that.parser),

--- a/src/internal_effect_untraced/syntax.ts
+++ b/src/internal_effect_untraced/syntax.ts
@@ -206,6 +206,11 @@ export const flatten = <Input, Error, Output>(
 ): Syntax.Syntax<Input, Error, Output, string> => transform(self, Chunk.join(""), Chunk.of)
 
 /** @internal */
+export const flattenNonEmpty = <Input, Error, Output>(
+  self: Syntax.Syntax<Input, Error, Output, Chunk.NonEmptyChunk<string>>
+): Syntax.Syntax<Input, Error, Output, string> => transform(self, Chunk.join(""), Chunk.of)
+
+/** @internal */
 export const manualBacktracking = <Input, Error, Output, Value>(
   self: Syntax.Syntax<Input, Error, Output, Value>
 ): Syntax.Syntax<Input, Error, Output, Value> =>
@@ -476,6 +481,12 @@ export const surroundedBy = dual<
     other: Syntax.Syntax<Input2, Error2, Output2, void>
   ) => Syntax.Syntax<Input & Input2, Error | Error2, Output | Output2, Value>
 >(2, (self, other) => zipRight(other, zipLeft(self, other)))
+
+/** @internal */
+export const suspend = <Input, Error, Output, Value>(
+  self: LazyArg<Syntax.Syntax<Input, Error, Output, Value>>
+): Syntax.Syntax<Input, Error, Output, Value> =>
+  make(_parser.suspend(() => self().parser), _printer.suspend(() => self().printer))
 
 /** @internal */
 export const transform = dual<

--- a/src/internal_effect_untraced/syntax.ts
+++ b/src/internal_effect_untraced/syntax.ts
@@ -215,7 +215,8 @@ export const flattenNonEmpty = <Input, Error, Output>(
 /** @internal */
 export const flattenZippedStrings = <Input, Error, Output>(
   self: Syntax.Syntax<Input, Error, Output, readonly [string, string]>
-): Syntax.Syntax<Input, Error, Output, string> => transform(self, ReadonlyArray.join(""), (from) => tuple("", from))
+): Syntax.Syntax<Input, Error, Output, string> =>
+  transform(self, ReadonlyArray.join(""), (from) => tuple(from[0], from.slice(1)))
 
 /** @internal */
 export const manualBacktracking = <Input, Error, Output, Value>(

--- a/src/internal_effect_untraced/syntax.ts
+++ b/src/internal_effect_untraced/syntax.ts
@@ -4,6 +4,7 @@ import type { LazyArg } from "@effect/data/Function"
 import { dual, pipe } from "@effect/data/Function"
 import * as Option from "@effect/data/Option"
 import type { Predicate } from "@effect/data/Predicate"
+import * as ReadonlyArray from "@effect/data/ReadonlyArray"
 import { tuple } from "@effect/data/Tuple"
 import * as _parser from "@effect/parser/internal_effect_untraced/parser"
 import * as _printer from "@effect/parser/internal_effect_untraced/printer"
@@ -210,6 +211,11 @@ export const flatten = <Input, Error, Output>(
 export const flattenNonEmpty = <Input, Error, Output>(
   self: Syntax.Syntax<Input, Error, Output, Chunk.NonEmptyChunk<string>>
 ): Syntax.Syntax<Input, Error, Output, string> => transform(self, Chunk.join(""), Chunk.of)
+
+/** @internal */
+export const flattenZippedStrings = <Input, Error, Output>(
+  self: Syntax.Syntax<Input, Error, Output, readonly [string, string]>
+): Syntax.Syntax<Input, Error, Output, string> => transform(self, ReadonlyArray.join(""), (from) => tuple("", from))
 
 /** @internal */
 export const manualBacktracking = <Input, Error, Output, Value>(

--- a/src/internal_effect_untraced/syntax.ts
+++ b/src/internal_effect_untraced/syntax.ts
@@ -4,7 +4,6 @@ import type { LazyArg } from "@effect/data/Function"
 import { dual, pipe } from "@effect/data/Function"
 import * as Option from "@effect/data/Option"
 import type { Predicate } from "@effect/data/Predicate"
-import * as ReadonlyArray from "@effect/data/ReadonlyArray"
 import { tuple } from "@effect/data/Tuple"
 import * as _parser from "@effect/parser/internal_effect_untraced/parser"
 import * as _printer from "@effect/parser/internal_effect_untraced/printer"
@@ -211,12 +210,6 @@ export const flatten = <Input, Error, Output>(
 export const flattenNonEmpty = <Input, Error, Output>(
   self: Syntax.Syntax<Input, Error, Output, Chunk.NonEmptyChunk<string>>
 ): Syntax.Syntax<Input, Error, Output, string> => transform(self, Chunk.join(""), Chunk.of)
-
-/** @internal */
-export const flattenZippedStrings = <Input, Error, Output>(
-  self: Syntax.Syntax<Input, Error, Output, readonly [string, string]>
-): Syntax.Syntax<Input, Error, Output, string> =>
-  transform(self, ReadonlyArray.join(""), (from) => tuple(from[0], from.slice(1)))
 
 /** @internal */
 export const manualBacktracking = <Input, Error, Output, Value>(

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -193,7 +193,7 @@ describe.concurrent("Parser", () => {
 
   parserTest(
     "zipLeft",
-    Syntax.zipLeft(Syntax.anyChar, Syntax.asPrinted(Syntax.anyChar, void 0, "?")),
+    Syntax.zipLeft(Syntax.anyChar, Syntax.asUnit(Syntax.anyChar, "?")),
     "he",
     Either.right("h")
   )

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -703,8 +703,8 @@ describe.concurrent("Parser", () => {
       Syntax.captureString(Syntax.repeat1(Syntax.digit)),
       Syntax.zip(Syntax.captureString(Syntax.repeat1(Syntax.letter)))
     ),
-    "12345abcd",
-    Either.right(["12345", "abcd"] as const)
+    "12345aBcd",
+    Either.right(["12345", "aBcd"] as const)
   )
 
   parserTest(

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -9,6 +9,31 @@ import { describe, expect, it } from "vitest"
 
 const charA = Syntax.as(Syntax.char("a"), "a")
 const charB = Syntax.as(Syntax.char("b"), "b")
+const recursive: Syntax.Syntax<string, string, string, string> = pipe(
+  Syntax.digit,
+  Syntax.zip(
+    pipe(Syntax.suspend(() => recursive), Syntax.orElse(() => Syntax.letter))
+  ),
+  Syntax.flattenZippedStrings
+)
+
+// TODO : not working
+/* const recursive1: Syntax.Syntax<string, string, string, string> = pipe(
+  Syntax.digit,
+  Syntax.zip(
+    pipe(Syntax.letter, Syntax.orElse(() => recursive1)),
+  Syntax.flattenZippedStrings
+  )
+
+  const recursive2: Syntax.Syntax<string, string, string, string> = pipe(
+  Syntax.digit,
+  Syntax.zip(
+    pipe(Syntax.letter, Syntax.orElse(() => Syntax.suspend(() => recursive2))),
+  Syntax.flattenZippedStrings
+  )
+)
+
+)*/
 
 const parserTest = <Error, Result>(
   name: string,
@@ -741,5 +766,12 @@ describe.concurrent("Parser", () => {
     pipe(charA, Syntax.zip(charB), Syntax.flattenZippedStrings),
     "ab",
     Either.right("ab")
+  )
+
+  parserTest(
+    "Recursive with suspend",
+    recursive,
+    "123A",
+    Either.right("123A")
   )
 })

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -422,6 +422,7 @@ describe.concurrent("Parser", () => {
   //   "bc",
   //   Either.left(ParserError.failure(List.nil(), 0, "not 'a'"))
   // )
+  // It even fails with this more simple example
 
   parserTest(
     "atLeast - three passing",
@@ -719,5 +720,26 @@ describe.concurrent("Parser", () => {
     Syntax.not(Syntax.string("hello", void 0 as void), "it was hello"),
     "hello",
     Either.left(ParserError.failure(List.nil(), 5, "it was hello"))
+  )
+
+  parserTest(
+    "flatten",
+    pipe(charA, Syntax.repeat, Syntax.flatten),
+    "aaabc",
+    Either.right("aaa")
+  )
+
+  parserTest(
+    "flattenNonEmpty",
+    pipe(charA, Syntax.repeat1, Syntax.flattenNonEmpty),
+    "aaabc",
+    Either.right("aaa")
+  )
+
+  parserTest(
+    "flattenZippedStrings",
+    pipe(charA, Syntax.zip(charB), Syntax.flattenZippedStrings),
+    "ab",
+    Either.right("ab")
   )
 })

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -3,6 +3,7 @@ import * as Either from "@effect/data/Either"
 import { pipe } from "@effect/data/Function"
 import * as List from "@effect/data/List"
 import * as Option from "@effect/data/Option"
+import * as ReadonlyArray from "@effect/data/ReadonlyArray"
 import * as ParserError from "@effect/parser/ParserError"
 import * as Syntax from "@effect/parser/Syntax"
 import { describe, expect, it } from "vitest"
@@ -14,7 +15,7 @@ const recursive: Syntax.Syntax<string, string, string, string> = pipe(
   Syntax.zip(
     pipe(Syntax.suspend(() => recursive), Syntax.orElse(() => Syntax.letter))
   ),
-  Syntax.flattenZippedStrings
+  Syntax.transform(ReadonlyArray.join(""), (from) => [from[0], from.slice(1)] as const)
 )
 
 // TODO : not working
@@ -22,14 +23,14 @@ const recursive: Syntax.Syntax<string, string, string, string> = pipe(
   Syntax.digit,
   Syntax.zip(
     pipe(Syntax.letter, Syntax.orElse(() => recursive1)),
-  Syntax.flattenZippedStrings
+  Syntax.transform(ReadonlyArray.join(""), (from) => [from[0], from.slice(1)] as const)
   )
 
   const recursive2: Syntax.Syntax<string, string, string, string> = pipe(
   Syntax.digit,
   Syntax.zip(
     pipe(Syntax.letter, Syntax.orElse(() => Syntax.suspend(() => recursive2))),
-  Syntax.flattenZippedStrings
+   Syntax.transform(ReadonlyArray.join(""), (from) => [from[0], from.slice(1)] as const)
   )
 )
 
@@ -759,13 +760,6 @@ describe.concurrent("Parser", () => {
     pipe(charA, Syntax.repeat1, Syntax.flattenNonEmpty),
     "aaabc",
     Either.right("aaa")
-  )
-
-  parserTest(
-    "flattenZippedStrings",
-    pipe(charA, Syntax.zip(charB), Syntax.flattenZippedStrings),
-    "ab",
-    Either.right("ab")
   )
 
   parserTest(

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -768,4 +768,12 @@ describe.concurrent("Parser", () => {
     "123A",
     Either.right("123A")
   )
+
+  // TODO: Enters in infinite loop
+  /*parserTest(
+    "regex with between",
+    Syntax.flatten(Syntax.regex(pipe(RegEx.anyDigit, RegEx.between(8, 8)), "8 digits expected")),
+    "20230704",
+    Either.right("20230705")
+  )*/
 })

--- a/test/Printer.ts
+++ b/test/Printer.ts
@@ -2,6 +2,7 @@ import * as Chunk from "@effect/data/Chunk"
 import * as Either from "@effect/data/Either"
 import { pipe } from "@effect/data/Function"
 import * as Option from "@effect/data/Option"
+import * as ReadonlyArray from "@effect/data/ReadonlyArray"
 import * as Printer from "@effect/parser/Printer"
 import * as Syntax from "@effect/parser/Syntax"
 import { describe, expect, it } from "vitest"
@@ -21,7 +22,7 @@ const recursive: Syntax.Syntax<string, string, string, string> = pipe(
   Syntax.zip(
     pipe(Syntax.suspend(() => recursive), Syntax.orElse(() => Syntax.letter))
   ),
-  Syntax.flattenZippedStrings
+  Syntax.transform(ReadonlyArray.join(""), (from) => [from[0], from.slice(1)] as const)
 )
 
 const printerTest = <Input, Error, Value>(
@@ -276,13 +277,6 @@ describe("Printer", () => {
     pipe(charA, Syntax.repeat1, Syntax.flattenNonEmpty),
     "aaa",
     Either.right("aaa")
-  )
-
-  printerTest(
-    "flattenZippedStrings",
-    pipe(charA, Syntax.zip(charB), Syntax.flattenZippedStrings),
-    "ab",
-    Either.right("ab")
   )
 
   printerTest(

--- a/test/Printer.ts
+++ b/test/Printer.ts
@@ -129,7 +129,7 @@ describe("Printer", () => {
 
   printerTest(
     "zipLeft",
-    Syntax.zipLeft(Syntax.anyChar, Syntax.asPrinted(Syntax.anyChar, void 0, "?")),
+    Syntax.zipLeft(Syntax.anyChar, Syntax.asUnit(Syntax.anyChar, "?")),
     "x",
     Either.right("x?")
   )

--- a/test/Printer.ts
+++ b/test/Printer.ts
@@ -57,7 +57,7 @@ describe("Printer", () => {
   )
 
   printerTest(
-    "filtered char, passing",
+    "filtered char, failing",
     pipe(
       Syntax.anyChar,
       Syntax.filter((char) => char === "h", "not 'h'")

--- a/test/Regex.ts
+++ b/test/Regex.ts
@@ -6,8 +6,8 @@ import * as fc from "fast-check"
 import { describe, expect, it } from "vitest"
 
 const IS_DIGIT_REGEX = /^[0-9]$/
-const IS_LETTER_REGEX = /^[a-z]$/
-const IS_LETTER_OR_DIGIT_REGEX = /^[a-z0-9]$/
+const IS_LETTER_REGEX = /^[a-z]$/i
+const IS_LETTER_OR_DIGIT_REGEX = /^[a-z0-9]$/i
 const IS_WHITESPACE_REGEX = /^\s$/
 
 const keywordStrings: ReadonlyArray<string> = [

--- a/test/examples/simpleXMLParser.ts
+++ b/test/examples/simpleXMLParser.ts
@@ -1,0 +1,120 @@
+import * as Chunk from "@effect/data/Chunk"
+import * as E from "@effect/data/Either"
+import { pipe } from "@effect/data/Function"
+import * as RA from "@effect/data/ReadonlyArray"
+import * as Syntax from "@effect/parser/Syntax"
+
+// Parses XML without prolog, attributes and namespaces
+
+interface XmlNode {
+  readonly name: string
+  readonly values: ReadonlyArray<string>
+  readonly children: ReadonlyArray<XmlNode>
+}
+
+const toParse = `<ROOT><A><B>u</B></A><C/></ROOT>`
+
+const tagStartString = "<"
+const tagEndString = ">"
+const closingMarkString = "/"
+const tagStart = Syntax.char(tagStartString)
+const tagEnd = Syntax.char(tagEndString)
+
+const ignoredWhiteSpaces = pipe(
+  Syntax.whitespace,
+  Syntax.repeat,
+  Syntax.asUnit(Chunk.of("") as Chunk.Chunk<string>)
+)
+
+const openingTagStart = tagStart
+const openingTagEnd = pipe(ignoredWhiteSpaces, Syntax.zipRight(tagEnd))
+
+const closingTagStart = Syntax.string(tagStartString + closingMarkString, undefined as void)
+const closingTagEnd = openingTagEnd
+
+const selfClosingTagStart = tagStart
+const selfClosingTagEnd = pipe(
+  ignoredWhiteSpaces,
+  Syntax.zipRight(Syntax.string(closingMarkString + tagEndString, undefined as void))
+)
+
+const tagLabelFirstLetter = pipe(
+  Syntax.letter,
+  Syntax.orElse(() => Syntax.charIn("_"))
+)
+
+const tagLabelNextLetters = pipe(
+  Syntax.alphaNumeric,
+  Syntax.orElse(() => Syntax.charIn(["-", "_", "."])),
+  Syntax.repeat,
+  Syntax.flatten
+)
+
+const tagLabel = pipe(
+  tagLabelFirstLetter,
+  Syntax.zip(tagLabelNextLetters),
+  Syntax.transform(RA.join(""), (from) => [from[0], from.slice(1)] as const)
+)
+
+const openingTag = Syntax.between(tagLabel, openingTagStart, openingTagEnd)
+const closingTag = Syntax.between(tagLabel, closingTagStart, closingTagEnd)
+
+const text = pipe(Syntax.charNotIn(tagStartString), Syntax.repeat1, Syntax.flattenNonEmpty)
+const selfClosingTag: Syntax.Syntax<string, string, string, XmlNode> = pipe(
+  tagLabel,
+  Syntax.between(selfClosingTagStart, selfClosingTagEnd),
+  Syntax.transform(
+    (to) => ({ name: to, values: [], children: [] } as XmlNode),
+    (from) => from.name
+  )
+)
+const xmlNode: Syntax.Syntax<string, string, string, XmlNode> = pipe(
+  Syntax.zipLeft(openingTag, ignoredWhiteSpaces),
+  Syntax.zip(
+    pipe(
+      Syntax.suspend(() => xmlNode),
+      Syntax.zipLeft(ignoredWhiteSpaces),
+      Syntax.orElseEither(() => text),
+      Syntax.repeat
+    )
+  ),
+  Syntax.zip(closingTag),
+  Syntax.transformEither(
+    (to) =>
+      to[0][0] !== to[1]
+        ? E.left(`Closing tag "${to[1]}" does not match with opening tag "${to[0][0]}"`)
+        : E.right({
+          name: to[1],
+          children: E.lefts(to[0][1]),
+          values: E.rights(to[0][1])
+        } as XmlNode),
+    (from) =>
+      E.right(
+        [
+          [
+            from.name,
+            pipe(
+              from.children,
+              RA.map(E.left),
+              Chunk.fromIterable,
+              (cs) => Chunk.concat(cs, pipe(from.values, RA.map(E.right), Chunk.fromIterable))
+            )
+          ] as const,
+          from.name
+        ] as const
+      )
+  ),
+  Syntax.orElse(() => selfClosingTag)
+)
+
+it("simpleXMLParser - recursive", () => {
+  const result = pipe(xmlNode, Syntax.parseStringWith(toParse, "recursive"))
+  expect(result).toEqual(E.right({
+    name: "ROOT",
+    children: [
+      { name: "A", children: [{ name: "B", children: [], values: ["u"] }], values: [] },
+      { name: "C", children: [], values: [] }
+    ],
+    values: []
+  }))
+})

--- a/test/examples/simpleXMLParser.ts
+++ b/test/examples/simpleXMLParser.ts
@@ -12,7 +12,7 @@ interface XmlNode {
   readonly children: ReadonlyArray<XmlNode>
 }
 
-const toParse = `<ROOT><A><B>u</B></A><C/></ROOT>`
+const toParse = "<ROOT><A><B >u</B></A><C/></ROOT>"
 
 const tagStartString = "<"
 const tagEndString = ">"
@@ -117,4 +117,8 @@ it("simpleXMLParser - recursive", () => {
     ],
     values: []
   }))
+  if (E.isRight(result)) {
+    const result1 = pipe(xmlNode, Syntax.printString(result.right))
+    expect(result1).toEqual(E.right("<ROOT><A><B>u</B></A><C></C></ROOT>"))
+  }
 })


### PR DESCRIPTION
Hi,

I have corrected a few more bugs, namely:
- corrected repeatWithSeparator in syntax.ts
- misuse of asPrinted in test/Printer.ts
- corrected IS_LETTER_REGEX in regex.ts (only lowercase were considered letters) and modified tests accordingly
- added suspend, flattenNonEmpty and flattenZippedStrings to parser.ts, Parser.ts, syntax.ts and Syntax.ts. I added corresponding tests
- I desperately tried to replace chunks by arrays at the surface of the api. But it turned out to be a bad idea because the transform combinator calls  the to and from functions written by the user from inside the parser. Not only we would have to keep turning arrays into chunks and vice-versa, but it is in fact impossible to handle as you can have deeply nested arrays, some resulting from the api and others from the user... So I guess we'll have to live with chunks
- I implemented the missing tests in Effect parser (as compared to Zio Parser). However, there remains a bug in the stack-safe version of the atLeast parser. I would need some help to correct it. I also discovered the regex parser does not work with RegEx.atMost (infinite loop). I added a commented test
- Globally, the parser works well: I was able to write a light version of an XML parser. Will send it over when I am satisfied with it. However, recursivity must be used with care. So

This works:
```ts
import { pipe } from "@effect/data/Function"
import * as Syntax from "@effect/parser/Syntax"

const grammar: Syntax.Syntax<string, string, string, string> = pipe(
  Syntax.digit,
  Syntax.zipLeft(
    pipe(Syntax.suspend(() => grammar), Syntax.orElse(() => Syntax.letter), Syntax.asUnit("?"))
  )
)

const result = Syntax.parseStringWith(grammar, "123A", "recursive")

console.log(result)
````

But this does not (), both with the stack-safe and the recursive impelmentations:
```ts
import { pipe } from "@effect/data/Function"
import * as Syntax from "@effect/parser/Syntax"

const grammar: Syntax.Syntax<string, string, string, string> = pipe(
  Syntax.digit,
  Syntax.zipLeft(
    pipe(Syntax.letter, Syntax.orElse(() => grammar), Syntax.asUnit("?"))
  )
)

const result = Syntax.parseStringWith(grammar, "123A", "recursive")

console.log(result)
````

And this fails equally:
```ts
import { pipe } from "@effect/data/Function"
import * as Syntax from "@effect/parser/Syntax"

const grammar: Syntax.Syntax<string, string, string, string> = pipe(
  Syntax.digit,
  Syntax.zipLeft(
    pipe(Syntax.letter, Syntax.orElse(() => Syntax.suspend(() => grammar)), Syntax.asUnit("?"))
  )
)

const result = Syntax.parseStringWith(grammar, "123A", "recursive")

console.log(result)
````
